### PR TITLE
Update python dependency name

### DIFF
--- a/composing-projects-using-docker-compose.md
+++ b/composing-projects-using-docker-compose.md
@@ -15,7 +15,7 @@ Go the directory where you've cloned the repository that came with this article.
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python2 make g++
 
 WORKDIR /app
 

--- a/containerizing-a-multi-container-javascript-application.md
+++ b/containerizing-a-multi-container-javascript-application.md
@@ -196,7 +196,7 @@ Go to the directory where you've cloned the project codes. Inside there, go insi
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python2 make g++
 
 WORKDIR /app
 


### PR DESCRIPTION
Updates python dependency name to `python2` in containerizing-a-multi-container-javascript-application.md otherwise build fails with:

```
$ docker image build --tag notes-api .
Sending build context to Docker daemon  37.89kB
Step 1/14 : FROM node:lts-alpine as builder
 ---> 70055606aaca
Step 2/14 : RUN apk add --no-cache python make g++
 ---> Running in 58654f2d156c
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  python (no such package):
    required by: world[python]
The command '/bin/sh -c apk add --no-cache python make g++' returned a non-zero code: 1
```

**EDIT:** Also updates it in the composing-projects-using-docker-compose.md file in the next section.