### PR TITLE
Fix typos in "Container Manipulation Basics"

### DIFF
--- a/container-manipulation-basics.md
+++ b/container-manipulation-basics.md
@@ -336,7 +336,7 @@ docker container ls
 # 0d74e14091dc   fhsinchy/hello-dock   "/docker-entrypoint.…"   About a minute ago   Up About a minute   0.0.0.0:8888->80/tcp   hello-dock-volatile
 ```
 
-Now if stop the container and then check again with the `container ls --all` command:
+Now if you stop the container and then check again with the `container ls --all` command:
 
 ```text
 docker container stop hello-dock-volatile

--- a/container-manipulation-basics.md
+++ b/container-manipulation-basics.md
@@ -411,7 +411,7 @@ docker run alpine uname -a
 
 In this command, I've executed the `uname -a` command inside an Alpine Linux container. Scenarios like this where all you want is to execute a certain command inside a certain container are pretty common.
 
-Assume that you want encode a string using the `base64` program which is something available in almost any Linux or Unix based operating system but not on Windows. In this situation you can quickly spin up a container using images like [busybox](https://hub.docker.com/_/busybox) and let it do the job.
+Assume that you want to encode a string using the `base64` program which is something available in almost any Linux or Unix based operating system but not on Windows. In this situation you can quickly spin up a container using images like [busybox](https://hub.docker.com/_/busybox) and let it do the job.
 
 The generic syntax for encoding a string using `base64` is as follows:
 

--- a/container-manipulation-basics.md
+++ b/container-manipulation-basics.md
@@ -409,7 +409,7 @@ docker run alpine uname -a
 # Linux f08dbbe9199b 5.8.0-22-generic #23-Ubuntu SMP Fri Oct 9 00:34:40 UTC 2020 x86_64 Linux
 ```
 
-In this command, I've executed the `uname -a` command inside an Alpine Linux container. Scenarios like this where all you want is to execute a certain command inside a certain container is pretty common.
+In this command, I've executed the `uname -a` command inside an Alpine Linux container. Scenarios like this where all you want is to execute a certain command inside a certain container are pretty common.
 
 Assume that you want encode a string using the `base64` program which is something available in almost any Linux or Unix based operating system but not on Windows. In this situation you can quickly spin up a container using images like [busybox](https://hub.docker.com/_/busybox) and let it do the job.
 

--- a/container-manipulation-basics.md
+++ b/container-manipulation-basics.md
@@ -435,7 +435,7 @@ docker container run --rm busybox sh -c "echo -n my-secret | base64"
 # bXktc2VjcmV0
 ```
 
-What happens here is, in a `container run` command, whatever you pass after the image name gets passed to the default entry-point of the image. An entrypoint is like a gateway to the image. Most of the images except the executable images \(explained in the [Working With Executable Images](container-manipulation-basics.md#working-with-executable-images) sub-section\), uses shell or `sh` as the default entry-point. So any valid shell command can be passed to them as arguments.
+What happens here is, in a `container run` command, whatever you pass after the image name gets passed to the default entry-point of the image. An entrypoint is like a gateway to the image. Most of the images except the executable images \(explained in the [Working With Executable Images](container-manipulation-basics.md#working-with-executable-images) sub-section\), use shell or `sh` as the default entry-point. So any valid shell command can be passed to them as arguments.
 
 ## Working With Executable Images
 

--- a/manipulating-containers.md
+++ b/manipulating-containers.md
@@ -89,7 +89,7 @@ docker container ls
 # 9f21cb777058        fhsinchy/hello-dock   "/docker-entrypoint.…"   5 seconds ago       Up 5 seconds        0.0.0.0:8080->80/tcp   gifted_sammet
 ```
 
-As you can see in the output, a container named `gifted_sammet` is running. In was created `5 seconds ago` and the status is the status is `Up 5 seconds,` which indicates that the container is running fine since it's creation.
+As you can see in the output, a container named `gifted_sammet` is running. In was created `5 seconds ago` and the status is `Up 5 seconds,` which indicates that the container is running fine since it's creation.
 
 The id if the container is `b6ada76e29c1` which is the first 12 characters of the full container id. The full container id is `9f21cb77705810797c4b847dbd330d9c732ffddba14fb435470567a7a3f46cdc` which is 64 characters long. This full container id was printed as the output of the `docker container run` command in the previous section.
 


### PR DESCRIPTION
Fixes a couple of typos, adds missing words and removes duplicates in "Container Manipulation Basics" chapter