### PR TITLE
Update ubuntu version to Focal Fossa and fix minor typo

### DIFF
--- a/image-manipulation-basics.md
+++ b/image-manipulation-basics.md
@@ -258,7 +258,7 @@ Before diving into writing some code, let's plan out the process first. The imag
 Now that you have a plan, let's begin by opening up old `Dockerfile` and update its contet as follows:
 
 ```text
-FROM ubuntu:latest
+FROM ubuntu:focal
 
 RUN apt-get update && \
     apt-get install build-essential\ 
@@ -306,7 +306,7 @@ Now to build an image using this code, execute the following command:
 ```text
 docker image build --tag custom-nginx:built .
 
-# Step 1/7 : FROM ubuntu:latest
+# Step 1/7 : FROM ubuntu:focal
 #  ---> d70eaf7277ea
 # Step 2/7 : RUN apt-get update &&     apt-get install build-essential                    libpcre3                     libpcre3-dev                     zlib1g                     zlib1g-dev                     libssl-dev                     -y &&     apt-get clean && rm -rf /var/lib/apt/lists/*
 #  ---> Running in 2d0aa912ea47
@@ -345,7 +345,7 @@ This code is alright but there are some places where improvements can be made.
 Open up the `Dockerfile` file and update it's content as follows:
 
 ```text
-FROM ubuntu:latest
+FROM ubuntu:focal
 
 RUN apt-get update && \
     apt-get install build-essential\ 
@@ -376,7 +376,7 @@ RUN cd ${FILENAME} && \
         --with-http_ssl_module && \
     make && make install
 
-RUN rm -rf /${FILENAME}}
+RUN rm -rf /${FILENAME}
 
 CMD ["nginx", "-g", "daemon off;"]
 ```
@@ -392,7 +392,7 @@ Rest of the code is almost unchanged. You should be able to understand the usage
 ```text
 docker image build --tag custom-nginx:built-v2 .
 
-# Step 1/9 : FROM ubuntu:latest
+# Step 1/9 : FROM ubuntu:focal
 #  ---> d70eaf7277ea
 # Step 2/9 : RUN apt-get update &&     apt-get install build-essential                    libpcre3                     libpcre3-dev                     zlib1g                     zlib1g-dev                     libssl-dev                     -y &&     apt-get clean && rm -rf /var/lib/apt/lists/*
 #  ---> cbe1ced3da11
@@ -485,7 +485,7 @@ docker image ls
 In order to find out the root cause, let's have a look at the `Dockerfile` first:
 
 ```text
-FROM ubuntu:latest
+FROM ubuntu:focal
 
 RUN apt-get update && \
     apt-get install build-essential\ 
@@ -516,7 +516,7 @@ RUN cd ${FILENAME} && \
         --with-http_ssl_module && \
     make && make install
 
-RUN rm -rf /${FILENAME}}
+RUN rm -rf /${FILENAME}
 
 CMD ["nginx", "-g", "daemon off;"]
 ```
@@ -526,7 +526,7 @@ As you can see on line 3, the `RUN` instruction installs a lot of stuff. Althoug
 To do so, update your `Dockerfile` as follows:
 
 ```text
-FROM ubuntu:latest
+FROM ubuntu:focal
 
 EXPOSE 80
 
@@ -583,7 +583,7 @@ Let's build an image using this `Dockerfile` and see the differences.
 docker image build --tag custom-nginx:built .
 
 # Sending build context to Docker daemon  1.057MB
-# Step 1/7 : FROM ubuntu:latest
+# Step 1/7 : FROM ubuntu:focal
 #  ---> f63181f19b2f
 # Step 2/7 : EXPOSE 80
 #  ---> Running in 006f39b75964


### PR DESCRIPTION
## Description
Whenever the ubuntu version is mentioned, it was changed from `latest` to `focal`.
This change was done because of a found error while building the nginx server 
from source: it raisen an error because at this time (2023-04-19) no packages 
for `openssl1.1` have been published for the jammy-jellyfish ubuntu release.

The easiest fix was to lock the ubuntu version to `focal-fossa`, which has the 
package ready for install from `apt`.

Also, at ln 379 was fixed a double bracket typo.

## Related Issue
At the moment the command `docker image build --tag custom-nginx:built .` is 
executed, the following errors show:

```bash
❯ docker image build --tag custom-nginx:built .
[+] Building 6.0s (6/10)
 => [internal] load build definition from Dockerfile                                                   0.0s
 => => transferring dockerfile: 899B                                                                   0.0s
 => [internal] load .dockerignore                                                                      0.0s
 => => transferring context: 2B                                                                        0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest                                       1.6s
 => CACHED [1/6] FROM docker.io/library/ubuntu:latest@sha256:67211c14fa74f070d27cc59d69a7fa9aeff8e28e  0.0s
 => => resolve docker.io/library/ubuntu:latest@sha256:67211c14fa74f070d27cc59d69a7fa9aeff8e28ea118ef3  0.0s
 => [internal] load build context                                                                      0.0s
 => => transferring context: 1.05MB                                                                    0.0s
 => ERROR [2/6] RUN apt-get update &&     apt-get install build-essential                    libpcre3  4.3s
------
 > [2/6] RUN apt-get update &&     apt-get install build-essential                    libpcre3                     libpcre3-dev                     zlib1g                     zlib1g-dev                     libssl1.1                     libssl-dev                     -y &&     apt-get clean && rm -rf /var/lib/apt/lists/*:
#5 0.438 Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
#5 0.568 Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
#5 0.813 Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
#5 0.905 Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [108 kB]
#5 0.971 Get:5 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [917 kB]
#5 0.995 Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
#5 1.214 Get:7 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
#5 1.284 Get:8 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [909 kB]
#5 1.331 Get:9 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [23.2 kB]
#5 1.332 Get:10 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [914 kB]
#5 1.683 Get:11 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
#5 1.685 Get:12 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
#5 1.688 Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1258 kB]
#5 1.737 Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1151 kB]
#5 1.753 Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [28.6 kB]
#5 1.754 Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [967 kB]
#5 1.908 Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [49.4 kB]
#5 2.131 Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [23.3 kB]
#5 2.528 Fetched 26.5 MB in 2s (11.7 MB/s)
#5 2.528 Reading package lists...
#5 3.279 Reading package lists...
#5 3.961 Building dependency tree...
#5 4.123 Reading state information...
#5 4.184 E: Unable to locate package libssl1.1
#5 4.184 E: Couldn't find any package by glob 'libssl1.1'
#5 4.184 E: Couldn't find any package by regex 'libssl1.1'
------
executor failed running [/bin/sh -c apt-get update &&     apt-get install build-essential                    libpcre3                     libpcre3-dev                     zlib1g                     zlib1g-dev                     libssl1.1                     libssl-dev                     -y &&     apt-get clean && rm -rf /var/lib/apt/lists/*]: exit code: 100
```

The root cause is the Ubuntu version (Jammy Jellyfish).

Course of action was:

Lock the Ubuntu version to the one used when the book's current version was written.


## Motivation and Context
This change was done to help future readers from getting the same error and save
them debugging time

## How Has This Been Tested?
The image building process was run to confirm the fix was successful and proceed
with the pull request.
