### PR TITLE
Update image-creation-basics.md

### DIFF
--- a/image-creation-basics.md
+++ b/image-creation-basics.md
@@ -258,7 +258,7 @@ Before diving into writing some code, let's plan out the process first. The imag
 Now that you have a plan, let's begin by opening up old `Dockerfile` and update its content as follows:
 
 ```text
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install build-essential\ 


### PR DESCRIPTION
 `libssl1.1` is deprecated and `Ubuntu:latest` uses `libssl3`. I have tried updating to `libssl3` but was getting some errors . To fix the issue i have updated the ubuntu version to compatible version .