### PR TITLE
apk add python is not avalable, need change python3

### DIFF
--- a/composing-projects-using-docker-compose/README.md
+++ b/composing-projects-using-docker-compose/README.md
@@ -15,7 +15,7 @@ Go the directory where you've cloned the repository that came with this article.
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 
@@ -172,7 +172,7 @@ docker-compose --file docker-compose.yaml up --detach
 #
 # Step 1/13 : FROM node:lts-alpine as builder
 #  ---> 471e8b4eb0b2
-# Step 2/13 : RUN apk add --no-cache python make g++
+# Step 2/13 : RUN apk add --no-cache python3 make g++
 #  ---> Running in 197056ec1964
 ### LONG INSTALLATION STUFF GOES HERE ###
 # Removing intermediate container 197056ec1964
@@ -438,7 +438,7 @@ docker-compose --file docker-compose.yaml up --detach
 # 
 # Step 1/13 : FROM node:lts-alpine as builder
 #  ---> 471e8b4eb0b2
-# Step 2/13 : RUN apk add --no-cache python make g++
+# Step 2/13 : RUN apk add --no-cache python3 make g++
 #  ---> Running in 8a4485388fd3
 ### LONG INSTALLATION STUFF GOES HERE ###
 # Removing intermediate container 8a4485388fd3

--- a/containerizing-a-multi-container-javascript-application/README.md
+++ b/containerizing-a-multi-container-javascript-application/README.md
@@ -196,7 +196,7 @@ Go to the directory where you've cloned the project codes. Inside there, go insi
 FROM node:lts-alpine as builder
 
 # install dependencies for node-gyp
-RUN apk add --no-cache python make g++
+RUN apk add --no-cache python3 make g++
 
 WORKDIR /app
 


### PR DESCRIPTION
https://stackoverflow.com/questions/62169568/docker-alpine-linux-python-missing

There is a StackOverflow statement that says the command is now not working and that you need to change it to python2 or python3.

However, when I actually tried it, I get a message that python2 can't be found either, so I have to change it to python3.

Unfortunately, the execution log appears on a wsl basis, which is inconsistent with existing documents, so I didn't change the log... but I need to change python3 for working dockerfile.

<img width="919" height="477" alt="image" src="https://github.com/user-attachments/assets/d7c13ece-4760-44fd-b183-a4d5a75b5bae" />
